### PR TITLE
Added browserify dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -17,5 +17,8 @@
       "mydb/index.js": "index.js",
       "mydb/document.js": "document.js"
     }
+  },
+  "devDependencies": {
+    "browserify": "2.35.1"
   }
 }


### PR DESCRIPTION
Note: This hasn't been tested other than running `browserify index.js` and seeing that it successfully completes the processing.

This depends on https://github.com/cloudup/mongo-query/pull/18 being merged and published.