### PR TITLE
add a `baseURL` option to resolve Document instances against

### DIFF
--- a/document.js
+++ b/document.js
@@ -3,6 +3,7 @@
  * Module dependencies.
  */
 
+var resolve = require('url/').resolve;
 var query = require('mongo-query');
 var request = require('superagent');
 var dot = require('dot-component');
@@ -319,10 +320,13 @@ Document.prototype.load = function(url, fn){
       debug('loading %s with headers %j', url, manager.headers);
     }
 
-    // if in node, try to prefix the url if relative
-    if ('undefined' != typeof process && '/' == url[0]) {
-      url = (socket.secure ? 'https' : 'http') + '://' +
-        socket.hostname + ':' + socket.port + url;
+    // prefix the base url if relative
+    if ('/' == url[0]) {
+      // compute absolute URL based on `baseURL` property,
+      // otherwise default to relative to the mydb Socket URL
+      var base = manager.baseURL || (socket.secure ? 'https' : 'http') + '://' +
+          socket.hostname + ':' + socket.port + url;
+      url = resolve(base, url);
     }
 
     // keep track of current url

--- a/index.js
+++ b/index.js
@@ -52,6 +52,7 @@ function Manager(url, opts){
   opts = opts || {};
   this.agent = opts.agent || false;
   this.headers = opts.headers || {};
+  this.baseURL = opts.baseURL || null;
   this.connected = false;
   this.subscriptions = {};
   this.bufferedOps = {};

--- a/package.json
+++ b/package.json
@@ -19,6 +19,7 @@
     "engine.io-client": "1.5.1",
     "json3": "3.3.2",
     "mongo-query": "0.5.7",
-    "superagent": "0.21.0"
+    "superagent": "0.21.0",
+    "url": "0.10.3"
   }
 }


### PR DESCRIPTION
This changes the default "relative URL" behavior in the web browser.
Consider a host page `http://example.com` connecting to a mydb
server `http://mydbserver.com`.

Before, doing `db.get('/foo')` would result in resolving against
the host page (http://example.com/foo).

Now, by default `db.get('/foo')` will resolve against the mydb
Socket URL (http://mydbserver.com/foo).

Thus, this is a breaking change (but only in the web browser…
in Node.js it was already relative to the mydb socket URL…)

In order to get the original functionality back, you may pass
in a `baseURL` string to resolve against as an option to the
mydb Manager constructor.

``` js
options.baseURL = window.location.origin;
```

(also see https://www.npmjs.com/package/base-url)